### PR TITLE
feat: add 256-bit encryption operations support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -15,3 +15,14 @@ export type ctBool = bigint
 export type ctUint = bigint
 
 export type ctString = { value: Array<bigint> }
+
+
+export type itUint256 = {
+    ciphertext: { ciphertextHigh: bigint; ciphertextLow: bigint };
+    signature: Uint8Array;
+  };
+
+export type ctUint256 = {
+    ciphertextHigh: bigint;
+    ciphertextLow: bigint;
+  };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
+    "lib": ["es2021"],
     "module": "commonjs",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Add prepareIT256() and decryptUint256() functions to support 256-bit plaintext encryption and decryption operations. Includes helper functions and type definitions for 256-bit ciphertext handling.