### PR TITLE
feat(sdk): add signed int256 encrypt/IT helpers

### DIFF
--- a/src/crypto_utils.ts
+++ b/src/crypto_utils.ts
@@ -1,6 +1,6 @@
 import forge from 'node-forge'
 import { BaseWallet, getBytes, SigningKey, solidityPacked, solidityPackedKeccak256, hexlify, Wallet } from 'ethers'
-import { BuildItUint256WithSignerParams, CtUint256Like, ctString, ctUint, ctUint256, itString, itUint, itUint256, itUint256Signed, SerializableCtUint, SerializableCtUint256 } from './types'
+import { BuildItUint256WithSignerParams, CtUint256Like, ctInt256, ctString, ctUint, ctUint256, itInt256, itString, itUint, itUint256, itUint256Signed, SerializableCtUint, SerializableCtUint256 } from './types'
 import { bigintToBytesBE, bytesToBigint, bytesToHex, ciphertextBytesToCtUint256, CT_SIZE, ctUint256ToBytes, ctUintToBytes, HEX_BASE } from './bytes'
 
 const BLOCK_SIZE = 16 // AES block size in bytes
@@ -13,6 +13,27 @@ function assertUintInRange(plaintext: bigint, maxBits: number, errorMessage: str
         throw new RangeError(errorMessage)
     }
     return value
+}
+
+function assertIntInRange(plaintext: bigint, bits: number, errorMessage: string): bigint {
+    const value = BigInt(plaintext)
+    const min = -(1n << BigInt(bits - 1))
+    const max = (1n << BigInt(bits - 1)) - 1n
+    if (value < min || value > max) {
+        throw new RangeError(errorMessage)
+    }
+    return value
+}
+
+/** Maps a signed plaintext into unsigned two's-complement bits for AES encrypt. */
+function toTwosComplementUint(plaintext: bigint, bits: number): bigint {
+    return plaintext < 0n ? (1n << BigInt(bits)) + plaintext : plaintext
+}
+
+/** Interprets an unsigned ciphertext plaintext as signed two's-complement. */
+function fromTwosComplementUint(unsigned: bigint, bits: number): bigint {
+    const signBit = 1n << BigInt(bits - 1)
+    return unsigned >= signBit ? unsigned - (1n << BigInt(bits)) : unsigned
 }
 
 function assertAesKeySize(key: Uint8Array): void {
@@ -710,8 +731,8 @@ export function encryptUint(plaintext: bigint, userKey: string): ctUint {
  * Encrypts an unsigned value into a {@link ctUint256} without building an IT signature.
  *
  * Values up to 128 bits use compact encoding; larger values up to 256 bits use
- * full two-block encoding. For signed submission use {@link prepareIT256} or
- * {@link buildItUint256WithSigner} instead.
+ * full two-block encoding. For signed submission use {@link prepareIT256},
+ * {@link prepareSignedIT256}, or {@link buildItUint256WithSigner} instead.
  *
  * @param plaintext - Unsigned value up to 256 bits.
  * @param userKey - AES key (32 hex chars, optionally `0x`-prefixed).
@@ -996,6 +1017,74 @@ export function prepareIT256(
         ciphertext: ciphertextBytesToCtUint256(ct),
         signature
     }
+}
+
+/**
+ * Encrypts a signed int256 into a {@link ctInt256} without building an IT signature.
+ *
+ * Negative values are encoded as 256-bit two's complement, then encrypted with
+ * the same wire format as {@link encryptUint256}.
+ *
+ * @param plaintext - Signed value in `[-(2^255), 2^255 - 1]`.
+ * @param userKey - AES key (32 hex chars, optionally `0x`-prefixed).
+ * @returns Encrypted ctInt256 ciphertext.
+ * @throws RangeError if `plaintext` is outside int256 range.
+ * @throws Error if the key is invalid.
+ */
+export function encryptInt256(plaintext: bigint, userKey: string): ctInt256 {
+    const value = assertIntInRange(
+        plaintext,
+        MAX_PLAINTEXT_BIT_SIZE,
+        "Plaintext size must fit in int256."
+    )
+    return encryptUint256(toTwosComplementUint(value, MAX_PLAINTEXT_BIT_SIZE), userKey)
+}
+
+/**
+ * Decrypts a {@link ctInt256} ciphertext and returns the signed plaintext.
+ *
+ * @param ciphertext - Encrypted int256 (same wire shape as ctUint256).
+ * @param userKey - AES key (32 hex chars, optionally `0x`-prefixed).
+ * @returns Signed plaintext in int256 range.
+ * @throws Error if the key is invalid.
+ */
+export function decryptInt256(ciphertext: ctInt256, userKey: string): bigint {
+    return fromTwosComplementUint(
+        decryptUint256(ciphertext, userKey),
+        MAX_PLAINTEXT_BIT_SIZE
+    )
+}
+
+/**
+ * Prepares a signed int256 input text ({@link itInt256}) for smart contract submission.
+ *
+ * Encodes `plaintext` as 256-bit two's complement, then delegates to
+ * {@link prepareIT256} for encrypt + private-key IT signature.
+ *
+ * @param plaintext - Signed value in `[-(2^255), 2^255 - 1]`.
+ * @param sender - Wallet and user AES key.
+ * @param contractAddress - Target contract address.
+ * @param functionSelector - 4-byte function selector.
+ * @returns Signed 256-bit input text.
+ * @throws RangeError if `plaintext` is outside int256 range.
+ */
+export function prepareSignedIT256(
+    plaintext: bigint,
+    sender: { wallet: BaseWallet; userKey: string },
+    contractAddress: string,
+    functionSelector: string,
+): itInt256 {
+    const value = assertIntInRange(
+        plaintext,
+        MAX_PLAINTEXT_BIT_SIZE,
+        "Plaintext size must fit in int256."
+    )
+    return prepareIT256(
+        toTwosComplementUint(value, MAX_PLAINTEXT_BIT_SIZE),
+        sender,
+        contractAddress,
+        functionSelector
+    )
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,3 +89,20 @@ export type SerializableCtUint256 =
         ciphertextLow?: SerializableCtUint;
       }
     | [SerializableCtUint, SerializableCtUint];
+
+/**
+ * On-chain encrypted signed 256-bit integer.
+ *
+ * Wire format is identical to {@link ctUint256}; plaintext is interpreted as
+ * two's-complement int256 after decryption.
+ */
+export type ctInt256 = {
+    ciphertextHigh: bigint;
+    ciphertextLow: bigint;
+};
+
+/** Signed 256-bit input text for smart contract submission (private-key path). */
+export type itInt256 = {
+    ciphertext: ctInt256;
+    signature: Uint8Array;
+};

--- a/tests/unit/typedIntCrypto.test.ts
+++ b/tests/unit/typedIntCrypto.test.ts
@@ -1,0 +1,93 @@
+import forge from 'node-forge'
+import {
+    decryptInt256,
+    decryptUint256,
+    encryptInt256,
+    encryptUint256,
+    prepareSignedIT256
+} from '../../src'
+import { createTestSender, TEST_CONSTANTS } from '../helpers'
+
+jest.mock('node-forge', () => {
+    const defaultForge = jest.requireActual('node-forge')
+
+    return {
+        ...defaultForge,
+        random: {
+            ...defaultForge.random,
+            getBytesSync: jest.fn()
+        }
+    }
+})
+
+const AES_KEY = TEST_CONSTANTS.USER_KEY
+const CONTRACT_ADDRESS = TEST_CONSTANTS.CONTRACT_ADDRESS
+const FUNCTION_SELECTOR = TEST_CONSTANTS.FUNCTION_SELECTOR
+
+describe('typed int256 ciphertext helpers', () => {
+    beforeEach(() => {
+        (forge.random.getBytesSync as jest.Mock).mockReturnValue('ABCDEFGHIJKLMNOP')
+    })
+
+    describe('encryptInt256 / decryptInt256', () => {
+        test.each([
+            0n,
+            1n,
+            -1n,
+            42n,
+            -42n,
+            (2n ** 255n) - 1n,
+            -(2n ** 255n)
+        ])('round-trips %s', (value) => {
+            const ciphertext = encryptInt256(value, AES_KEY)
+            expect(decryptInt256(ciphertext, AES_KEY)).toBe(value)
+        })
+
+        test('negative plaintext shares wire format with uint two\'s complement', () => {
+            const signed = encryptInt256(-1n, AES_KEY)
+            expect(decryptUint256(signed, AES_KEY)).toBe((1n << 256n) - 1n)
+            expect(decryptInt256(encryptUint256((1n << 256n) - 1n, AES_KEY), AES_KEY)).toBe(-1n)
+        })
+
+        test('rejects values outside int256', () => {
+            expect(() => encryptInt256(2n ** 255n, AES_KEY)).toThrow(RangeError)
+            expect(() => encryptInt256(-(2n ** 255n) - 1n, AES_KEY)).toThrow(RangeError)
+        })
+    })
+
+    describe('prepareSignedIT256', () => {
+        test.each([
+            -1n,
+            0n,
+            12345n,
+            -(2n ** 200n)
+        ])('round-trips %s through decryptInt256', (value) => {
+            const { ciphertext } = prepareSignedIT256(
+                value,
+                createTestSender(),
+                CONTRACT_ADDRESS,
+                FUNCTION_SELECTOR
+            )
+            expect(decryptInt256(ciphertext, AES_KEY)).toBe(value)
+        })
+
+        test('matches encryptInt256 ciphertext for the same random block', () => {
+            const value = -99n
+            const encrypted = encryptInt256(value, AES_KEY)
+            const { ciphertext } = prepareSignedIT256(
+                value,
+                createTestSender(),
+                CONTRACT_ADDRESS,
+                FUNCTION_SELECTOR
+            )
+            expect(encrypted).toEqual(ciphertext)
+        })
+
+        test('rejects values outside int256', () => {
+            const sender = createTestSender()
+            expect(() =>
+                prepareSignedIT256(2n ** 255n, sender, CONTRACT_ADDRESS, FUNCTION_SELECTOR)
+            ).toThrow(RangeError)
+        })
+    })
+})


### PR DESCRIPTION
Unsigned uint256 already on main; protocol needs twos-complement int256 for UPNL/settlement. Wrap encryptUint256/prepareIT256